### PR TITLE
`request` must be promisified in lib/cli.js

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -19,6 +19,7 @@ const request = require('request');
 
 // Promisify libraries
 Promise.promisifyAll(azure);
+Promise.promisifyAll(request, { multiArgs: true });
 
 const aux = process.env.BUDDY_PARSE_AUX_URL || 'https://parse.buddy.com/';
 


### PR DESCRIPTION
Consumer code may call directly into lib/cli.js for automation purposes. Therefore, promisification of `request` must occur there such that the relevant async methods have been created.

This was removed in d194d42cf4c778dbf85511148440f24f23e55e18.